### PR TITLE
Clarify ML workflow script usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ python demo_ml_system.py              # Sistema ML básico
 python demo_training_ml.py            # Treinamento de modelos
 python demo_pipeline_ml.py            # Pipeline completo
 ```
+> Para o workflow completo em produção utilize `python executar_workflow_ml.py`.
+> O script `demo_pipeline_ml.py` é indicado apenas para demonstrações e testes.
 
 ### **APIs e Integrações**
 ```bash

--- a/demo_pipeline_ml.py
+++ b/demo_pipeline_ml.py
@@ -1,6 +1,9 @@
 """
 Demonstração do Pipeline de Machine Learning Completo
 Testa todas as fases: preparação de dados, treinamento e geração de recomendações
+
+Este script é voltado para demonstrações e testes locais. Para executar o
+workflow completo em produção, utilize `executar_workflow_ml.py`.
 """
 
 import sys

--- a/executar_workflow_ml.py
+++ b/executar_workflow_ml.py
@@ -2,6 +2,10 @@
 """
 Script principal para executar o workflow completo de Machine Learning do ApostaPro.
 Executa em sequência: preparação de dados, treinamento de modelos e geração de recomendações.
+
+Use este script como ponto de entrada para execuções completas em ambiente de
+produção. Para uma demonstração mais simples voltada a desenvolvimento ou
+testes rápidos, utilize `demo_pipeline_ml.py`.
 """
 
 import logging


### PR DESCRIPTION
## Summary
- clarify that `executar_workflow_ml.py` is the full production workflow entrypoint
- note that `demo_pipeline_ml.py` is for local demos and testing
- document script roles in README to prevent confusion

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68a14c06dde883328c0e672becc709ba